### PR TITLE
Access attributes with state_attr in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sensor:
     power_output:
       friendly_name: "Power Output"
       value_template: >
-        {{ states.sensor.peloton_username.attributes.Power }}
+        {{ state_attr('sensor.peloton_username', "Workout Type" ) }}
 ```
 
 ## Use Cases


### PR DESCRIPTION
Thanks for all of your work on this extension. I have just set it up perfectly first time with your docs. When trying to access the Workout Type I couln't get it to work due to the whitespace. Hope you dont mind this edit...

Happy to help with any further work on the project if you would like 😄 