### PR TITLE
Add Version Tag To manifest.json

### DIFF
--- a/custom_components/peloton/manifest.json
+++ b/custom_components/peloton/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "peloton",
   "name": "Peloton",
-  "version": "0.4.0"
+  "version": "0.4.0",
   "documentation": "https://github.com/edwork/homeassistant-peloton-sensor",
   "dependencies": [],
   "codeowners": ["@edwork"],

--- a/custom_components/peloton/manifest.json
+++ b/custom_components/peloton/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "peloton",
   "name": "Peloton",
+  "version": "0.4.0"
   "documentation": "https://github.com/edwork/homeassistant-peloton-sensor",
   "dependencies": [],
   "codeowners": ["@edwork"],


### PR DESCRIPTION
Home Assistant now requires custom components to have a version tag in the manifest.json file. For now, any custom component without a version tag will log a warning. In the future, custom components that do not include a version tag will be blocked at startup. See details [here](https://github.com/home-assistant/core/pull/45919)