### PR TITLE
bump up required version of pylotoncycle

### DIFF
--- a/custom_components/peloton/manifest.json
+++ b/custom_components/peloton/manifest.json
@@ -5,5 +5,5 @@
   "documentation": "https://github.com/edwork/homeassistant-peloton-sensor",
   "dependencies": [],
   "codeowners": ["@edwork"],
-  "requirements": ["pylotoncycle==0.5.0"]
+  "requirements": ["pylotoncycle==0.5.1"]
 }


### PR DESCRIPTION
I should note that I haven't tested this. 

However, I do know that the base module wasn't working because a field was changed on the api, which caused the pylotoncycle module to error out. This is a very minor update to allow the base module to work again.