### PR TITLE
Change device_state_attributes to extra_state_attributes

### DIFF
--- a/custom_components/peloton/sensor.py
+++ b/custom_components/peloton/sensor.py
@@ -70,7 +70,7 @@ class PelotonSensor(Entity):
         return self._state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return device specific state attributes."""
         return self._attributes
 


### PR DESCRIPTION
2021.12 introduces a new message in the logs for any component using device_state_attributes instead of extra_state_attributes. This minor change is a preventative measure prior to the official 2021.12 release- As it stands, the log message instructs users to contact the developer to make this change.