### PR TITLE
Fix for users who do not have a heart rate monitor

### DIFF
--- a/custom_components/peloton/sensor.py
+++ b/custom_components/peloton/sensor.py
@@ -114,8 +114,6 @@ class PelotonSensor(Entity):
             self._attributes.update({"Output Kj":str((workout_latest["total_work"]//1000)+(workout_latest["total_work"]%1000>0))})
             self._attributes.update({"Distance Mi":str(stats_latest["summaries"][1]["value"])})
             self._attributes.update({"Calories KCal":str(int(stats_latest["summaries"][2]["value"]))})
-            self._attributes.update({"Heart Rate Average Bpm":str(stats_latest["metrics"][4]["average_value"])})
-            self._attributes.update({"Heart Rate Max Bpm":str(stats_latest["metrics"][4]["max_value"])})
             self._attributes.update({"Resistance Average %":str(stats_latest["metrics"][2]["average_value"])})
             self._attributes.update({"Resistance Max %":str(stats_latest["metrics"][2]["max_value"])})
             self._attributes.update({"Speed Average Mph":str(stats_latest["metrics"][3]["average_value"])})
@@ -129,7 +127,6 @@ class PelotonSensor(Entity):
             self._attributes.update({"Total Work":str(workout_latest["overall_summary"]["total_work"])})
             self._attributes.update({"Instructor":str(workout_latest["instructor_name"])})
             self._attributes.update({"Workout Image":str(workout_latest["ride"]["image_url"])})
-            self._attributes.update({"Heart Rate Bpm":str(stats_latest["metrics"][4]["average_value"])})
             self._attributes.update({"Resistance %":str(stats_latest["metrics"][2]["average_value"])})
             # Need to see if these attributes show when a ride is in progress, or remove. 
             #self._attributes.update({"Speed Mph":str(workout_latest["overall_summary"]["speed"])})
@@ -138,3 +135,11 @@ class PelotonSensor(Entity):
             #self._attributes.update({"Power W":str(workout_latest["overall_summary"]["power"])})
         except:
             _LOGGER.warning("Error on parsing State Attributes, something in the API may have changed")
+        
+        # Update Heart Rate State Attributes if present
+        try:
+            self._attributes.update({"Heart Rate Average Bpm":str(stats_latest["metrics"][4]["average_value"])})
+            self._attributes.update({"Heart Rate Max Bpm":str(stats_latest["metrics"][4]["max_value"])})
+            self._attributes.update({"Heart Rate Bpm":str(stats_latest["metrics"][4]["average_value"])})
+        except:
+            _LOGGER.warning("Error on parsing State Attributes for Heart Rate functionality. It's possible that you do not have a heart rate monitor and can ignore this warning")

--- a/custom_components/peloton/sensor.py
+++ b/custom_components/peloton/sensor.py
@@ -116,10 +116,16 @@ class PelotonSensor(Entity):
             self._attributes.update({"Calories KCal":str(int(stats_latest["summaries"][2]["value"]))})
             self._attributes.update({"Resistance Average %":str(stats_latest["metrics"][2]["average_value"])})
             self._attributes.update({"Resistance Max %":str(stats_latest["metrics"][2]["max_value"])})
-            self._attributes.update({"Speed Average Mph":str(stats_latest["metrics"][3]["average_value"])})
-            self._attributes.update({"Speed Max Mph":str(stats_latest["metrics"][3]["max_value"])})
-            self._attributes.update({"Speed Average Kph":str(round(((stats_latest["metrics"][3]["average_value"])*1.60934),2))})
-            self._attributes.update({"Speed Max Kph":str(round(((stats_latest["metrics"][3]["max_value"])*1.60934),2))})
+            if stats_latest["metrics"][3]["display_unit"] == "kph":
+                kph_multiplier = 1
+                mph_multiplier = 0.60934
+            else:
+                kph_multiplier = 1.60934
+                mph_multiplier = 1
+            self._attributes.update({"Speed Average Mph":str(round(((stats_latest["metrics"][3]["average_value"])*mph_multiplier),2))})
+            self._attributes.update({"Speed Max Mph":str(round(((stats_latest["metrics"][3]["max_value"])*mph_multiplier),2))})
+            self._attributes.update({"Speed Average Kph":str(round(((stats_latest["metrics"][3]["average_value"])*kph_multiplier),2))})
+            self._attributes.update({"Speed Max Kph":str(round(((stats_latest["metrics"][3]["max_value"])*kph_multiplier),2))})
             self._attributes.update({"Cadence Average Rpm":str(stats_latest["metrics"][1]["average_value"])})
             self._attributes.update({"Cadence Max Rpm":str(stats_latest["metrics"][1]["max_value"])})
             self._attributes.update({"Power Average W":str(stats_latest["metrics"][0]["average_value"])})


### PR DESCRIPTION
I ran into an issue where my Attributes were not displaying correctly in my LoveLace card. I discovered that it is due to my not having metrics for Heart Rate which was causing the try/except to fail part way through updating the attributes. Users who have a heart rate sensor likely would never even notice.

In the json returned from the Peloton API, stats_latest["metrics"][4] does not exist. It stops at stats_latest["metrics"][3].

Below is a screenshot of the missing values in the LoveLace card as well as the array that was returned from Peloton for your convenience.


![screenshot of the issue](https://i.imgur.com/Ju8WUDZ.png)


```json
"metrics":[
      {
         "display_name":"Output",
         "display_unit":"watts",
         "max_value":425,
         "average_value":276,
         "values":[
            322,
            318,
            308,
            298,
            292,
            425,
            376,
            338,
            348,
            305,
            328,
            308,
            335,
            285,
            339,
            348,
            318,
            293,
            242
         ],
         "slug":"output"
      },
      {
         "display_name":"Cadence",
         "display_unit":"rpm",
         "max_value":111,
         "average_value":79,
         "values":[
            89,
            94,
            90,
            91,
            89,
            86,
            82,
            86,
            100,
            110,
            82,
            83,
            97,
            87,
            87,
            85,
            76,
            76,
            68
         ],
         "slug":"cadence"
      },
      {
         "display_name":"Resistance",
         "display_unit":"%",
         "max_value":74,
         "average_value":59,
         "values":[
            57,
            57,
            56,
            56,
            56,
            73,
            73,
            62,
            58,
            58,
            74,
            63,
            59,
            56,
            73,
            73,
            72,
            62,
            62
         ],
         "slug":"resistance"
      },
      {
         "display_name":"Speed",
         "display_unit":"kph",
         "max_value":45.5,
         "average_value":38.8,
         "values":[
            41.2,
            41.0,
            40.5,
            40.0,
            39.7,
            45.5,
            43.6,
            41.9,
            42.3,
            40.3,
            41.4,
            40.5,
            41.8,
            39.4,
            41.9,
            42.3,
            40.9,
            39.7,
            37.0
         ],
         "slug":"speed"
      }
   ]
```