### PR TITLE
Fix issue with hacs.json.

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,3 +1,4 @@
 {
-  "name": "Peloton"
+  "name": "Peloton",
+  "render_readme": true
 }


### PR DESCRIPTION
Integration shows "The developer has not provided any more information for this repository" in HACS. This change fixes that. Integration will need its version number bumped and a new release for the change to propagate.