### PR TITLE
add current metric summary values

### DIFF
--- a/custom_components/peloton/__init__.py
+++ b/custom_components/peloton/__init__.py
@@ -133,7 +133,7 @@ def compile_quant_data(
                         value  # Convert kcal to Wh
                         if isinstance((value := summary.get("value")), int)
                         else None,
-                        "kcal",
+                        str(summary.get("display_unit")),
                         None,
                     )
                 }
@@ -144,6 +144,18 @@ def compile_quant_data(
                     "distance": PelotonSummary(
                         value
                         if isinstance((value := summary.get("value")), float)
+                        else None,
+                        str(summary.get("display_unit")),
+                        None,
+                    )
+                }
+            )
+        if summary.get("slug") == "total_output":
+            summaries.update(
+                {
+                    "totaloutput": PelotonSummary(
+                        value
+                        if isinstance((value := summary.get("value")), int)
                         else None,
                         str(summary.get("display_unit")),
                         None,
@@ -163,8 +175,11 @@ def compile_quant_data(
                         int(max_val)
                         if isinstance((max_val := metric.get("max_value")), int)
                         else None,
-                        int(avg)
-                        if isinstance((avg := metric.get("average_value")), int)
+                        int(avg_val)
+                        if isinstance((avg_val := metric.get("average_value")), int)
+                        else None,
+                        int(val)
+                        if isinstance((val := metric.get("values")[len(metric.get("values"))-1]), int)
                         else None,
                         str(metric.get("display_unit")),
                         None,
@@ -181,6 +196,9 @@ def compile_quant_data(
                         int(avg)
                         if isinstance((avg := metric.get("average_value")), int)
                         else None,
+                        int(value)
+                        if isinstance((value := metric.get("values")[len(metric.get("values"))-1]), int)
+                        else None,
                         "%",
                         None,
                     )
@@ -195,6 +213,9 @@ def compile_quant_data(
                         else None,
                         avg
                         if isinstance((avg := metric.get("average_value")), float)
+                        else None,
+                       value
+                        if isinstance((value := metric.get("values")[len(metric.get("values"))-1]), float)
                         else None,
                         str(metric.get("display_unit")),
                         None,
@@ -211,6 +232,9 @@ def compile_quant_data(
                         int(avg)
                         if isinstance((avg := metric.get("average_value")), int)
                         else None,
+                        int(value)
+                        if isinstance((value := metric.get("values")[len(metric.get("values"))-1]), int)
+                        else None,
                         "rpm",
                         None,
                     )
@@ -225,6 +249,9 @@ def compile_quant_data(
                         else None,
                         int(avg)
                         if isinstance((avg := metric.get("average_value")), int)
+                        else None,
+                        int(value)
+                        if isinstance((value := metric.get("values")[len(metric.get("values"))-1]), int)
                         else None,
                         "W",
                         SensorDeviceClass.POWER,
@@ -250,8 +277,8 @@ def compile_quant_data(
             "End Time",
             datetime.fromtimestamp(workout_stats_summary["end_time"], user_timezone)
             if "end_time" in workout_stats_summary
-            and workout_stats_summary["end_time"] is not None or not 'null'
-            else datetime.fromtimestamp(workout_stats_summary["start_time"], user_timezone),
+            and workout_stats_summary["end_time"] is not None
+            else None,
             None,
             SensorDeviceClass.TIMESTAMP,
             SensorStateClass.MEASUREMENT,
@@ -259,7 +286,7 @@ def compile_quant_data(
         ),
         PelotonStat(
             "Duration",
-            round((duration_sec / 60), 2)
+            duration_sec / 60
             if (
                 (duration_sec := workout_stats_summary.get("ride", {}).get("duration"))
                 and duration_sec is not None
@@ -314,6 +341,14 @@ def compile_quant_data(
             "mdi:fire",
         ),
         PelotonStat(
+            "Total Output",
+            getattr(summaries.get("totaloutput"), "total", None),
+            getattr(summaries.get("totaloutput"), "unit", None),
+            getattr(summaries.get("totaloutput"), "device_class", None),
+            SensorStateClass.MEASUREMENT,
+            "mdi:lightning-bolt",
+        ),
+        PelotonStat(
             "Heart Rate: Average",
             getattr(metrics.get("heart_rate"), "avg_val", None),
             getattr(metrics.get("heart_rate"), "unit", None),
@@ -324,6 +359,14 @@ def compile_quant_data(
         PelotonStat(
             "Heart Rate: Max",
             getattr(metrics.get("heart_rate"), "max_val", None),
+            getattr(metrics.get("heart_rate"), "unit", None),
+            getattr(metrics.get("heart_rate"), "device_class", None),
+            SensorStateClass.MEASUREMENT,
+            "mdi:heart-pulse",
+        ),
+        PelotonStat(
+            "Heart Rate: Current",
+            getattr(metrics.get("heart_rate"), "value", None),
             getattr(metrics.get("heart_rate"), "unit", None),
             getattr(metrics.get("heart_rate"), "device_class", None),
             SensorStateClass.MEASUREMENT,
@@ -346,6 +389,14 @@ def compile_quant_data(
             "mdi:network-strength-4",
         ),
         PelotonStat(
+            "Resistance: Current",
+            getattr(metrics.get("resistance"), "value", None),
+            getattr(metrics.get("resistance"), "unit", None),
+            getattr(metrics.get("resistance"), "device_class", None),
+            SensorStateClass.MEASUREMENT,
+            "mdi:network-strength-1",
+        ),
+        PelotonStat(
             "Speed: Average",
             getattr(metrics.get("speed"), "avg_val", None),
             getattr(metrics.get("speed"), "unit", None),
@@ -362,6 +413,14 @@ def compile_quant_data(
             "mdi:speedometer",
         ),
         PelotonStat(
+            "Speed: Current",
+            getattr(metrics.get("speed"), "value", None),
+            getattr(metrics.get("speed"), "unit", None),
+            getattr(metrics.get("speed"), "device_class", None),
+            SensorStateClass.MEASUREMENT,
+            "mdi:speedometer-slow",
+        ),
+        PelotonStat(
             "Cadence: Average",
             getattr(metrics.get("cadence"), "avg_val", None),
             getattr(metrics.get("cadence"), "unit", None),
@@ -376,5 +435,13 @@ def compile_quant_data(
             getattr(metrics.get("cadence"), "device_class", None),
             SensorStateClass.MEASUREMENT,
             "mdi:fan-chevron-up",
+        ),
+        PelotonStat(
+            "Cadence: Current",
+            getattr(metrics.get("cadence"), "value", None),
+            getattr(metrics.get("cadence"), "unit", None),
+            getattr(metrics.get("cadence"), "device_class", None),
+            SensorStateClass.MEASUREMENT,
+            "mdi:fan-clock",
         ),
     ]

--- a/custom_components/peloton/sensor.py
+++ b/custom_components/peloton/sensor.py
@@ -43,6 +43,7 @@ class PelotonMetric:
 
     max_val: int | float | None
     avg_val: int | float | None
+    value: int | float | None
     unit: str | None  # Useful for mph vs kmph
     device_class: SensorDeviceClass | None
 


### PR DESCRIPTION
Will add:
1. current metric values for cadence, resistance, speed, and heart-rate in addition to the avg and max reported
<img width="575" alt="Screenshot 2023-01-06 at 11 24 04 PM" src="https://user-images.githubusercontent.com/19197386/211130843-aa3542b8-b302-44fb-b023-2df6cfffa989.png">
<img width="545" alt="Screenshot 2023-01-06 at 11 23 56 PM" src="https://user-images.githubusercontent.com/19197386/211130858-880ef276-7372-4121-a9b3-c11530bca00c.png">
<img width="551" alt="Screenshot 2023-01-06 at 11 23 44 PM" src="https://user-images.githubusercontent.com/19197386/211130864-ddf09247-4afa-4001-9b32-a7993aaac655.png">

2. total final output value for ride
<img width="632" alt="Screenshot 2023-01-06 at 11 24 07 PM" src="https://user-images.githubusercontent.com/19197386/211130873-ecb95f26-773c-426d-a13f-951c922c09be.png">

Reference Issue: #44 