### PR TITLE
Utilize async_forward_entry_setups & Start/End time sensor StateClass Removal

### DIFF
--- a/custom_components/peloton/__init__.py
+++ b/custom_components/peloton/__init__.py
@@ -270,6 +270,7 @@ def compile_quant_data(
             else None,
             None,
             SensorDeviceClass.TIMESTAMP,
+            None,
             "mdi:timer-sand",
         ),
         PelotonStat(
@@ -280,6 +281,7 @@ def compile_quant_data(
             else datetime.fromtimestamp(workout_stats_summary["start_time"], user_timezone),
             None,
             SensorDeviceClass.TIMESTAMP,
+            None,
             "mdi:timer-sand-complete",
         ),
         PelotonStat(

--- a/custom_components/peloton/__init__.py
+++ b/custom_components/peloton/__init__.py
@@ -95,7 +95,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Store coordinator
     hass.data[DOMAIN][entry.entry_id] = coordinator
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/peloton/__init__.py
+++ b/custom_components/peloton/__init__.py
@@ -270,7 +270,6 @@ def compile_quant_data(
             else None,
             None,
             SensorDeviceClass.TIMESTAMP,
-            SensorStateClass.MEASUREMENT,
             "mdi:timer-sand",
         ),
         PelotonStat(
@@ -281,7 +280,6 @@ def compile_quant_data(
             else datetime.fromtimestamp(workout_stats_summary["start_time"], user_timezone),
             None,
             SensorDeviceClass.TIMESTAMP,
-            SensorStateClass.MEASUREMENT,
             "mdi:timer-sand-complete",
         ),
         PelotonStat(


### PR DESCRIPTION
- As of Home Assistant 2023.3, the integration will fail to start if it continues to utilize the `async_setup_platforms` function. Utilizing the `async_forward_entry_setups` function resolves this issue
- The StateClass of `MEASUREMENT` has been removed from the Start and End time sensors as Home Assistant complains (As of 2023.2b0) that these sensors are "using state class 'measurement' which is impossible considering device class ('timestamp') it is using; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author."  .....This makes sense as a start and end timestamp doesn't exactly fall under the measurement category.

Side Note: Home Assistant 2023.2b0 also complains about the Power Output sensor: `using state class 'measurement' which is impossible considering device class ('energy') it is using; Please update your configuration if your entity is manually configured, otherwise report it to the custom integration author.`

I have opted out of removing the StateClass there as the energy class, in my opinion, is a valid contender for the measurement state class. Frenck added another issue involving the duration class of the core history stat sensor raising the same error as a milestone to fix for 2023.2. So, I think it would be worthwhile to wait and see what is done in that case before removing the measurement class from the Power Output sensor as well.