### PR TITLE
Use standardized Home Assistant Units & Add new workout count sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This integration creates one of the below sensors for each user. The "Workout" b
 | Resistance: Max          | Sensor                  | %                   |                                                                                                 |                                                               |
 | Speed: Average           | Sensor                  | mph / kph           |                                                                                                 | Uses unit of measurement specified in user's Peloton profile. |
 | Speed: Max               | Sensor                  | mph / kph           |                                                                                                 | Uses unit of measurement specified in user's Peloton profile. |
+| Workout count               | Sensor                  |            |                                                                                                 | `These sensors are disabled by default.` <br> Available types: <br>   - Bike Bootcamp <br>   - Cardio <br>   - Cycling <br>   - Meditation <br>   - Row Bootcamp <br>   - Rowing <br>   - Running <br>   - Strength <br>   - Stretching <br>   - Tread Bootcamp <br>   - Walking <br>   - Yoga|
 
 ## Under the Hood
 

--- a/custom_components/peloton/manifest.json
+++ b/custom_components/peloton/manifest.json
@@ -6,6 +6,6 @@
   "issue_tracker": "https://github.com/edwork/homeassistant-peloton-sensor/issues",
   "documentation": "https://github.com/edwork/homeassistant-peloton-sensor",
   "codeowners": ["@edwork"],
-  "requirements": ["pylotoncycle==0.6.0"],
+  "requirements": ["git+https://github.com/RobertD502/pylotoncycle@dev#pylotoncycle==0.6.0.1"],
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
`__init__.py Changes:`

- Added Home Assistant Units/Unit enums:  PERCENTAGE, REVOLUTIONS_PER_MINUTE, UnitOfLength, UnitOfSpeed

- Import new PelotonWorkouts data class: used for workout count sensor

- Fetches user settings from user settings endpoint: used to determine if user set distance units to imperial or metric

- Distance and Speed sensors use user settings distance_unit to determine if to use Miles & Miles/hr or Kilometers & Kilometers/hr

- Cadence sensor unit set to revolutions per minute (rpm)

- Resistance sensors now use the standardized Home Assistant PERCENTAGE unit instead of typing out the % (in str format) unit ourselves

- Create sensors for workout counts --> these are disabled by default allowing users to enable which sensors they want to pull in data for


`sensor.py Changes:`

- Added PelotonWorkouts data class: used to hold data for workout count sensors.

- Added entity category and registry enabled default attributes to PelotonStat data class: allows us to set workout count sensor category to diagnostic and disable adding workout count sensors by default. These attributes can be used to customize future sensors.

- PelotonStatSensor uses entire PelotonStat object instead of stat_name: Needed to do this as the entity_category and entity_registry_enabled_default attributes have to be defined in the __init__ of the  PelotonStateSensor


`manifest Changes:`

- use Pylotoncycle library from RobertD502 fork: I deliberately set this version to `0.6.0.1` in case the original library maintainer merges the changes and publishes to PyPi - it is likely that they will bump the version to 0.6.1 or greater so we're preventing the possibility of having a version of pylotoncycle already installed within Home Assistant that is greater than the next one published to PyPi. 

`README Changes:`

- added Workout count sensors to sensors table