### PR TITLE
Fix I/O blocking caused by dateutil gettz function

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Peloton",
   "render_readme": true,
-  "homeassistant": "2023.1"
+  "homeassistant": "2024.6.0b0"
 }


### PR DESCRIPTION
Starting with Home Assistant `2024.6.0`, currently in beta, users will get a warning in their logs about dateutil's `gettz` function blocking the Home Assistant event loop.

1. In order to avoid this, I have converted the `compile_quant_data` function to be async so that we can easily utilize Home Assistant's dt util `async_get_time_zone` function. Using this function, instead of `tz.gettz`, prevents the integration from blocking the event loop.

[Link](https://developers.home-assistant.io/blog/2024/05/19/fix_zoneinfo_blocking_io) to HA dev blog about ZoneInfo and blocking the event loop.
[Link](https://github.com/home-assistant/core/commit/5a609c34bb8a7181d166c9e7f5d66aaa01034e47) to the PR when `async_get_time_zone` was first introduced.

2. Since, for the first time, the `async_get_time_zone` function became available in Home Assistant `2026.6.0b0`, I have also bumped the minimum required Home Assistant version in the `hacs.json` file to this version.

