### PR TITLE
Add reauth flow, check if values list for current sensors is not empty before attempting to get index

### DIFF
--- a/custom_components/peloton/strings.json
+++ b/custom_components/peloton/strings.json
@@ -7,12 +7,23 @@
           "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]"
         }
+      },
+      "reauth_confirm": {
+        "description": "Reauthenticate with your Peloton account credentials.",
+        "data": {
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]"
+        }
       }
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_account%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   }
 }

--- a/custom_components/peloton/translations/en.json
+++ b/custom_components/peloton/translations/en.json
@@ -1,17 +1,29 @@
 {
-  "config": {
-    "error": {
-      "cannot_connect": "Failed to connect",
-      "invalid_auth": "Invalid authentication",
-      "unknown": "Unexpected error"
-    },
-    "step": {
-      "user": {
-        "data": {
-          "username": "Username",
-          "password": "Password"
+    "config": {
+        "abort": {
+            "already_configured": "Peloton account is already configured",
+            "reauth_successful": "Re-authentication was successful"
+        },
+        "error": {
+            "cannot_connect": "Failed to connect",
+            "invalid_auth": "Invalid authentication",
+            "unknown": "Unexpected error"
+        },
+        "step": {
+            "user": {
+                "description": "Log in to your Peloton account.",
+                "data": {
+                    "username": "Username",
+                    "password": "Password"
+                }
+            },
+            "reauth_confirm": {
+                "description": "Reauthenticate with your Peloton account credentials.",
+                "data": {
+                    "username": "Username",
+                    "password": "Password"
+                }
+            }
         }
-      }
     }
-  }
 }


### PR DESCRIPTION
## Changes

* `Reauth flow has been added`: When credentials are no longer correct, a reauthentication message will appear for users allowing them to re-enter their credentials (as seen below).

![Peloton Reauth](https://github.com/edwork/homeassistant-peloton-sensor/assets/52541649/e6ed595e-f55c-41f5-bd70-9f33f48cf7d2)
* `Config version has been updated to version 2`: After users update the integration, the `async_migrate_entry` function will update their config entry version to 2 and set the unique ID equal to their peloton username. This way, we can prevent users trying to add multiple configurations with the same username - the config flow will get aborted if it sees that the username entered is already defined as a `unique_id` in a peloton config entry (as seen below).

![image](https://github.com/edwork/homeassistant-peloton-sensor/assets/52541649/49e06ab9-9cbb-458e-8378-b1435c6c628a)
* `Changed logging level to error when PelotonLoginException is encountered`: Just for better visibility, I changed the manually logged message from `warning` to `error`.
* `Check if the values list isn't empty before fetching the index`: For sensors dealing with "current" measurements, the values list is likely being cleared out when a new workout is started - the empty list is a direct cause of the index exception seen. Since python evaluates boolean conditions lazily, we can check to see if the list is not empty before trying to get an index within the list. When `metric.get("values")` returns an empty list, the code after the `and` comparison ( `isinstance((value := metric.get("values")[len(metric.get("values"))-1]), int)`) won't get evaluated and the value will get defined as None instead of facing an index error exception. With the value being set to None, HA will show the sensor as being `Unknown` which is correct when the API doesn't yet have a current value for the current workout.

## Related Issues
- Closes #89
- Closes #84 